### PR TITLE
Add web.options method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+##### Version 0.7.0:
+
+- (**breaking change**) Removed `Solid.identity.getWorkspaces` (no longer
+  relevant) and `getWritableProfiles` (duplicate code to `getProfile`)
+- Added TravisCI integration
+- Add `Solid.web.options()` method
+- Add support to `webUtil.parseAllowedMethods()` for
+  `Access-Control-Allow-Methods` headers
+
 ##### Version 0.6.0:
 
 - (**breaking change**) Rename export module name from `solid.js` to `solid`.

--- a/lib/solid-response.js
+++ b/lib/solid-response.js
@@ -52,9 +52,9 @@ function SolidResponse (xhrResponse) {
    * @type Object
    */
   this.allowedMethods =
-    parseAllowedMethods(xhrResponse.getResponseHeader('Allow'),
-      xhrResponse.getResponseHeader('Accept-Patch'),
-      xhrResponse.getResponseHeader('Access-Control-Allow-Methods')
+    parseAllowedMethods(
+      xhrResponse.getResponseHeader('Access-Control-Allow-Methods'),
+      xhrResponse.getResponseHeader('Accept-Patch')
     )
   /**
    * Name of the corresponding `.meta` resource

--- a/lib/solid-response.js
+++ b/lib/solid-response.js
@@ -53,7 +53,9 @@ function SolidResponse (xhrResponse) {
    */
   this.allowedMethods =
     parseAllowedMethods(xhrResponse.getResponseHeader('Allow'),
-      xhrResponse.getResponseHeader('Accept-Patch'))
+      xhrResponse.getResponseHeader('Accept-Patch'),
+      xhrResponse.getResponseHeader('Access-Control-Allow-Methods')
+    )
   /**
    * Name of the corresponding `.meta` resource
    * @property meta

--- a/lib/web-util.js
+++ b/lib/web-util.js
@@ -10,6 +10,8 @@
  * @method parseAllowedMethods
  * @param allowHeader {String} `Allow:` response header
  * @param acceptPatchHeader {String} `Accept-Patch` response header
+ * @param allowMethodsHeader {String} `Access-Control-Allow-Methods` response
+ *   header
  * @return {Object} Hashmap of verbs allowed by the server. Example:
  *   ```
  *   {
@@ -18,12 +20,14 @@
  *   }
  *   ```
  */
-function parseAllowedMethods (allowHeader, acceptPatchHeader) {
+function parseAllowedMethods (allowHeader, acceptPatchHeader,
+    allowMethodsHeader) {
   var allowedMethods = {}
   if (allowHeader) {
     var verbs = ['HEAD', 'GET', 'POST', 'PUT', 'DELETE', 'OPTIONS']
     verbs.forEach(function (methodName) {
-      if (allowHeader.indexOf(methodName) >= 0) {
+      if (allowHeader.indexOf(methodName) >= 0 ||
+          allowMethodsHeader.indexOf(methodName) >= 0) {
         allowedMethods[methodName] = true
       }
     })

--- a/lib/web-util.js
+++ b/lib/web-util.js
@@ -8,33 +8,31 @@
  * Extracts the allowed HTTP methods from the 'Allow' and 'Accept-Patch'
  * headers, and returns a hashmap of verbs allowed by the server
  * @method parseAllowedMethods
- * @param allowHeader {String} `Allow:` response header
- * @param acceptPatchHeader {String} `Accept-Patch` response header
  * @param allowMethodsHeader {String} `Access-Control-Allow-Methods` response
  *   header
- * @return {Object} Hashmap of verbs allowed by the server. Example:
+ * @param acceptPatchHeader {String} `Accept-Patch` response header
+ * @return {Object} Hashmap of verbs (in lowercase) allowed by the server for
+ *   the current user. Example:
  *   ```
  *   {
- *     'GET': true,
- *     'PUT': true
+ *     'get': true,
+ *     'put': true
  *   }
  *   ```
  */
-function parseAllowedMethods (allowHeader, acceptPatchHeader,
-    allowMethodsHeader) {
+function parseAllowedMethods (allowMethodsHeader, acceptPatchHeader) {
   var allowedMethods = {}
-  if (allowHeader) {
-    var verbs = ['HEAD', 'GET', 'POST', 'PUT', 'DELETE', 'OPTIONS']
+  if (allowMethodsHeader) {
+    var verbs = allowMethodsHeader.split(',')
     verbs.forEach(function (methodName) {
-      if (allowHeader.indexOf(methodName) >= 0 ||
-          allowMethodsHeader.indexOf(methodName) >= 0) {
-        allowedMethods[methodName] = true
+      if (methodName && allowMethodsHeader.indexOf(methodName) >= 0) {
+        allowedMethods[methodName.trim().toLowerCase()] = true
       }
     })
   }
   if (acceptPatchHeader &&
       acceptPatchHeader.indexOf('application/sparql-update') >= 0) {
-    this.allowedMethods.patch = true
+    allowedMethods.patch = true
   }
   return allowedMethods
 }

--- a/lib/web.js
+++ b/lib/web.js
@@ -98,6 +98,17 @@ var SolidWebClient = {
   },
 
   /**
+   * Issues an HTTP OPTIONS request. Useful for discovering server capabilities
+   * (`Accept-Patch:`, `Updates-Via:` for websockets, etc).
+   * @method head
+   * @param url {String} URL of a resource or container
+   * @return {Promise} Result of an HTTP HEAD operation (returns a meta object)
+   */
+  options: function options (url) {
+    return this.solidRequest(url, 'OPTIONS')
+  },
+
+  /**
    * Retrieves a resource via HTTP, parses it using the default parser
    * specified in `config.parser`, and returns the result.
    * @method getParsedGraph

--- a/test/unit/web-util-test.js
+++ b/test/unit/web-util-test.js
@@ -15,3 +15,37 @@ test('parse link header test', function (t) {
 
   t.deepEqual(expectedParsedLinks, actualParsedLinks)
 })
+
+test('parseAllowedMethods() test with no headers', function (t) {
+  t.plan(1)
+  t.deepEqual(webUtil.parseAllowedMethods(), {},
+    'Empty parseAllowedMethods() should result in an empty object')
+})
+
+test('parseAllowedMethods() test', function (t) {
+  t.plan(1)
+  let allowMethodsHeader = 'OPTIONS, HEAD, GET, POST, PUT, DELETE'
+  let acceptPatchHeader = 'application/sparql-update'
+  let expectedAllowedMethods = {
+    'delete': true,
+    'get': true,
+    'head': true,
+    'options': true,
+    'patch': true,
+    'post': true,
+    'put': true
+  }
+  let allowedMethods = webUtil.parseAllowedMethods(allowMethodsHeader,
+    acceptPatchHeader)
+  t.deepEqual(allowedMethods, expectedAllowedMethods)
+})
+
+test('parseAllowedMethods() does not support json-patch', function (t) {
+  t.plan(1)
+  let allowMethodsHeader = null
+  let acceptPatchHeader = 'application/json'
+  let expectedAllowedMethods = {}
+  let allowedMethods = webUtil.parseAllowedMethods(allowMethodsHeader,
+    acceptPatchHeader)
+  t.deepEqual(allowedMethods, expectedAllowedMethods, 'JSON-Patch method is not supported')
+})


### PR DESCRIPTION
Closes issue #17

- Add `Solid.web.options()` method
- Add support to `webUtil.parseAllowedMethods()` for
  `Access-Control-Allow-Methods` headers