### PR TITLE
Add convenience method that returns typeIndexes

### DIFF
--- a/lib/solid-profile.js
+++ b/lib/solid-profile.js
@@ -108,6 +108,10 @@ SolidProfile.prototype.initFromGraph = function initFromGraph (parsedProfile) {
   // Init storage
   this.externalResources.storage = parseLinks(parsedProfile, webId,
     rdf.sym(Vocab.PIM.storage))
+
+  // Init typeIndex
+  this.externalResources.typeIndexes = parseLinks(parsedProfile, webId,
+    rdf.sym(Vocab.SOLID.typeIndex))
 }
 
 /**
@@ -145,6 +149,15 @@ SolidProfile.prototype.preferences = function preferences () {
  */
 SolidProfile.prototype.storage = function storage () {
   return this.externalResources.storage
+}
+
+/**
+ * Convenience method, returns an array of type indexes for a user profile
+ * @method storage
+ * @return {Array<String>}
+ */
+SolidProfile.prototype.typeIndexes = function storage () {
+  return this.externalResources.typeIndexes
 }
 
 /**

--- a/lib/vocab.js
+++ b/lib/vocab.js
@@ -26,7 +26,8 @@ var Vocab = {
     'seeAlso': 'http://www.w3.org/2000/01/rdf-schema#seeAlso'
   },
   'SOLID': {
-    'inbox': 'http://www.w3.org/ns/solid/terms#inbox'
+    'inbox': 'http://www.w3.org/ns/solid/terms#inbox',
+    'typeIndex': 'https://www.w3.org/ns/solid/terms#typeIndex'
   }
 }
 


### PR DESCRIPTION
Implements #32 -- add method to expose type registry (`solid:typeIndex` terms).