### PR TITLE
Add unit tests for typeIndexes()

### DIFF
--- a/lib/solid-profile.js
+++ b/lib/solid-profile.js
@@ -22,7 +22,8 @@ function SolidProfile (profileUrl, parsedProfile, response) {
   this.externalResources = {
     inbox: null,
     preferences: [],
-    storage: []
+    storage: [],
+    typeIndexes: []
   }
 
   /**
@@ -153,10 +154,10 @@ SolidProfile.prototype.storage = function storage () {
 
 /**
  * Convenience method, returns an array of type indexes for a user profile
- * @method storage
+ * @method typeIndexes
  * @return {Array<String>}
  */
-SolidProfile.prototype.typeIndexes = function storage () {
+SolidProfile.prototype.typeIndexes = function typeIndexes () {
   return this.externalResources.typeIndexes
 }
 

--- a/lib/vocab.js
+++ b/lib/vocab.js
@@ -27,7 +27,7 @@ var Vocab = {
   },
   'SOLID': {
     'inbox': 'http://www.w3.org/ns/solid/terms#inbox',
-    'typeIndex': 'https://www.w3.org/ns/solid/terms#typeIndex'
+    'typeIndex': 'http://www.w3.org/ns/solid/terms#typeIndex'
   }
 }
 

--- a/test/resources/profile-ldnode.js
+++ b/test/resources/profile-ldnode.js
@@ -21,6 +21,8 @@ module.exports = `@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
        </settings/prefs.ttl>;
     sp:storage
        loc:;
+    terms:typeIndex
+       </settings/publicTypeIndex.ttl>;
     terms:inbox
        inbox:.
 <#key-1455289666916>

--- a/test/unit/solid-profile-test.js
+++ b/test/unit/solid-profile-test.js
@@ -10,7 +10,7 @@ var parsedProfileGraph = parseGraph(sampleProfileUrl,
   rawProfileSource, 'text/turtle')
 
 test('SolidProfile empty profile test', function (t) {
-  t.plan(7)
+  t.plan(8)
   let profile = new SolidProfile()
   t.notOk(profile.webId, 'Empty profile should not have webId set')
   t.notOk(profile.response, 'Empty profile - no response object')
@@ -19,6 +19,8 @@ test('SolidProfile empty profile test', function (t) {
     'Empty profile - no preferences')
   t.deepEqual(profile.storage(), [],
     'Empty profile - no storage')
+  t.deepEqual(profile.typeIndexes(), [],
+    'Empty profile - no type registry indexes')
   t.deepEqual(profile.relatedProfiles.sameAs, [],
     'Empty profile - no sameAs')
   t.deepEqual(profile.relatedProfiles.seeAlso, [],
@@ -58,5 +60,13 @@ test('SolidProfile storage test', function (t) {
   let profile = new SolidProfile(sampleProfileUrl, parsedProfileGraph)
   let expectedStorageLinks = ['https://localhost:8443/']
   t.deepEqual(profile.storage(), expectedStorageLinks)
+  t.end()
+})
+
+test('SolidProfile public type registry index test', function (t) {
+  let profile = new SolidProfile(sampleProfileUrl, parsedProfileGraph)
+  let expectedLinks =
+    ['https://localhost:8443/settings/publicTypeIndex.ttl']
+  t.deepEqual(profile.typeIndexes(), expectedLinks)
   t.end()
 })


### PR DESCRIPTION
- fix typeIndex vocab url (to `http`)

Follow-up to PR #40, implements issue #32.