### PR TITLE
Make withCredentials XHR parameter optional with web.get() etc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+##### Version 0.12.2:
+
+- Make `withCredentials` XHR parameter optional with `web.get()` (and other 
+  web requests). This is set by default, but can be suppressed with options.
+  Usage: `solid.web.get(url, { noCredentials = true })` 
+
 ##### Version 0.12.1:
 
 - Fixed `web.patch()`-related issue that was blocking `profile.registerType()`

--- a/lib/identity.js
+++ b/lib/identity.js
@@ -16,6 +16,7 @@ var SolidProfile = require('./solid/profile')
  * @method getProfile
  * @param profileUrl {String} WebId or Location of a user's profile.
  * @param [options] Options hashmap (see solid.web.solidRequest() function docs)
+ * @param [options.ignoreExtended=false] Do not load extended profile if true.
  * @return {Promise<SolidProfile>}
  */
 function getProfile (profileUrl, options) {
@@ -24,6 +25,7 @@ function getProfile (profileUrl, options) {
   options.headers = options.headers || {
     'Accept': 'text/turtle'
   }
+  options.noCredentials = true  // profiles are always public
   // Load main profile
   return webClient.get(profileUrl, options)
     .then(function (response) {

--- a/lib/web.js
+++ b/lib/web.js
@@ -41,11 +41,7 @@ var SolidWebClient = {
     var currentUrl = this.currentUrl()
     var currentIsHttps = currentUrl && currentUrl.slice(0, 6) === 'https:'
     var targetIsHttp = url && url.slice(0, 5) === 'http:'
-    if (currentIsHttps && targetIsHttp) {
-      return true
-    } else {
-      return false
-    }
+    return currentIsHttps && targetIsHttp
   },
 
   /**
@@ -67,6 +63,7 @@ var SolidWebClient = {
    * @param url {String} URL of the request
    * @param method {String} HTTP Verb ('GET', 'PUT', etc)
    * @param [options] Options hashmap
+   * @param [options.noCredentials=false] {Boolean} Don't use `withCredentials`
    * @param [options.forceProxy=false] {Boolean} Enforce using proxy URL if true
    * @param [options.headers={}] {Object} HTTP headers to send along
    *          with request
@@ -75,6 +72,7 @@ var SolidWebClient = {
    * @param [options.timeout=config.timeout] {Number} Request timeout in
    *          milliseconds.
    * @param [data] {Object} Optional data / payload
+   * @return {Promise<SolidResponse>}
    */
   solidRequest: function solidRequest (url, method, options, data) {
     options = options || {}
@@ -87,7 +85,9 @@ var SolidWebClient = {
     return new Promise(function (resolve, reject) {
       var http = new XMLHttpRequest()
       http.open(method, url)
-      http.withCredentials = true
+      if (!options.noCredentials) {
+        http.withCredentials = true
+      }
       for (var header in options.headers) {  // Add in optional headers
         http.setRequestHeader(header, options.headers[header])
       }
@@ -135,9 +135,6 @@ var SolidWebClient = {
    * Retrieves a resource or container by making an HTTP GET call.
    * @method get
    * @param url {String} URL of the resource or container to fetch
-   * @param [proxyUrl] {String} URL template of the proxy to use for CORS
-   *                          requests.
-   * @param [timeout] {Number} Request timeout in milliseconds.
    * @param [options] Options hashmap
    * @param [options.headers] {Object} HTTP headers to send along with request
    * @param [options.proxyUrl=config.proxyUrl] {String} Proxy URL to use for
@@ -197,7 +194,7 @@ var SolidWebClient = {
           var contentType = response.contentType()
           return graphUtil.parseGraph(location, response.raw(), contentType)
         })
-        .catch(function (reason) {
+        .catch(function () {
           // Suppress the error, no need to reject, just return null graph
           return null
         })
@@ -231,6 +228,8 @@ var SolidWebClient = {
    *                          requests. Defaults to `config.proxyUrl`.
    * @param timeout {Number} Request timeout in milliseconds.
    *                         Defaults to `config.timeout`.
+   * @param [suppressError=false] {Boolean} Resolve with a null graph on error
+   *   if true, reject otherwise. Set to true when using `Promise.all()`
    * @return {Promise<Object>|Object}
    */
   getParsedGraph: function getParsedGraph (url, proxyUrl, timeout,
@@ -283,7 +282,7 @@ var SolidWebClient = {
    * @method put
    * @param url {String} URL of the resource to be updated/created
    * @param data {Object} Data/payload of the resource to be created or updated
-   * @param mime {String} MIME Type of the resource to be created
+   * @param mimeType {String} MIME Type of the resource to be created
    * @return {Promise|Object} Result of PUT operation (returns parsed response
    *     meta object if successful, rejects with an anonymous error status
    *     object if not successful)


### PR DESCRIPTION
Provide a way for a developer to override the withCredentials setting.
Implements issue #67.

(`getProfile()` now doesn't use `withCredentials` when retrieving the profile doc).