### PR TITLE
Merge web.list() logic into web.get()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+##### Version 0.14.0:
+
+- Merge the `web.list()` functionality into `web.get()`. That is, if the result
+  of a `get()` call is a Container, return an instance of `SolidContainer` 
+  (as if `web.list()` was called instead).
+- Give a Deprecation warning on usage of `.list()`
+- Add an `isContainer()` helper method to `SolidResponse` and `SolidContainer`.
+- Give a Deprecation warning when `web.list()` is used.
+- (**breaking change**) `response.type` is now response `.types` (plural),
+  since Solid/LDP resources can have multiple types (for example, a Container
+  is of type `http://www.w3.org/ns/ldp#Container` and 
+  `http://www.w3.org/ns/ldp#BasicContainer` both).
+
 ##### Version 0.13.0:
 
 - Make `withCredentials` XHR parameter optional with `web.get()` (and other 

--- a/README.md
+++ b/README.md
@@ -390,7 +390,7 @@ solid.web.post(parentDir, data, slug, isContainer).then(
 
 To list the contents of a Solid container, use `solid.web.list()`.
 This returns a promise that resolves to a `SolidContainer` instance, 
-which will contained various useful properties:
+which will contain various useful properties:
 
 - A short name (`.name`) and absolute URI (`.uri`)
 - A `.parsedGraph` property for further RDF queries

--- a/lib/solid/container.js
+++ b/lib/solid/container.js
@@ -137,6 +137,14 @@ SolidContainer.prototype.initFromResponse =
   }
 
 /**
+ * Is this a Container instance (vs a regular resource).
+ * @returns {Boolean}
+ */
+SolidResource.prototype.isContainer = function isContainer () {
+  return true
+}
+
+/**
  * Returns true if there are no resources or containers inside this container.
  * @method isEmpty
  * @return {Boolean}

--- a/lib/solid/resource.js
+++ b/lib/solid/resource.js
@@ -72,6 +72,15 @@ SolidResource.prototype.initName = function initName () {
 }
 
 /**
+ * Is this a Container instance (vs a regular resource).
+ * (Is overridden in the subclass, `SolidContainer`)
+ * @returns {Boolean}
+ */
+SolidResource.prototype.isContainer = function isContainer () {
+  return false
+}
+
+/**
  * Returns true if this a given type matches this resource's types
  * @method isType
  * @param rdfClass {String}

--- a/lib/solid/response.js
+++ b/lib/solid/response.js
@@ -19,6 +19,7 @@ function SolidResponse (xhrResponse, method) {
     this.xhr = null
     this.user = ''
     this.method = null
+    this.types = []
     return
   }
   /**
@@ -26,9 +27,12 @@ function SolidResponse (xhrResponse, method) {
    *
    *   ```
    *   {
-   *     acl: 'resourceName.acl',
-   *     describedBy: 'resourceName.meta',
-   *     type: 'http://www.w3.org/ns/ldp#Resource'
+   *     acl: [ 'resourceName.acl' ],
+   *     describedBy: [ 'resourceName.meta' ],
+   *     type: [
+   *       'http://www.w3.org/ns/ldp#RDFResource',
+   *       'http://www.w3.org/ns/ldp#Resource'
+   *     ]
    *   }
    *   ```
    * @property linkHeaders
@@ -55,6 +59,9 @@ function SolidResponse (xhrResponse, method) {
    * @type String
    */
   this.acl = this.linkHeaders['acl']
+  if (this.acl) {
+    this.acl = this.acl[0]  // Extract the single .acl link
+  }
   /**
    * Hashmap of HTTP methods/verbs allowed by the server.
    * (If a verb is not allowed, it's not included.)
@@ -76,11 +83,19 @@ function SolidResponse (xhrResponse, method) {
    * @type String
    */
   this.meta = this.linkHeaders['meta'] || this.linkHeaders['describedBy']
+  if (this.meta) {
+    this.meta = this.meta[0]  // Extract the single .meta link
+  }
   /**
-   * LDP Type for the resource.
-   * Example: 'http://www.w3.org/ns/ldp#Resource'
+   * LDP Types for the resource.
+   * Example: [
+   *   'http://www.w3.org/ns/ldp#Resource',
+   *   'http://www.w3.org/ns/ldp#RDFResource'
+   * ]
+   * @property types
+   * @type Array<String>
    */
-  this.type = this.linkHeaders.type
+  this.types = this.linkHeaders.type || []
   /**
   * URL of the resource created or retrieved
   * @property url
@@ -132,12 +147,30 @@ SolidResponse.prototype.exists = function exists () {
 }
 
 /**
+ * Is this a Container instance (vs a regular resource).
+ * @returns {Boolean}
+ */
+SolidResponse.prototype.isContainer = function isContainer () {
+  return this.isType('http://www.w3.org/ns/ldp#Container')
+}
+
+/**
  * Returns true if the user is logged in with the server
  * @method isLoggedIn
  * @return {Boolean}
  */
 SolidResponse.prototype.isLoggedIn = function isLoggedIn () {
   return this.user // && this.user.slice(0, 4) === 'http'
+}
+
+/**
+ * Returns true if this a given type matches this resource's types
+ * @method isType
+ * @param rdfClass {String}
+ * @return {Boolean}
+ */
+SolidResponse.prototype.isType = function isType (rdfClass) {
+  return this.types.indexOf(rdfClass) !== -1
 }
 
 /**

--- a/lib/solid/response.js
+++ b/lib/solid/response.js
@@ -95,7 +95,7 @@ function SolidResponse (xhrResponse, method) {
   this.user = xhrResponse.getResponseHeader('User') || ''
   /**
    * URL of the corresponding websocket instance, for this resource
-   * Example: `wss://example.org/blog/hellow-world`
+   * Example: `wss://example.org/blog/hello-world`
    * @property websocket
    * @type String
    */

--- a/lib/util/web-util.js
+++ b/lib/util/web-util.js
@@ -59,12 +59,19 @@ function parseLinkHeader (link) {
     var href = split[0].substring(1)
     var ps = split[1]
     var s = ps.match(paramexp)
+
     for (var j = 0; j < s.length; j++) {
       var p = s[j]
       var paramsplit = p.split('=')
       // var name = paramsplit[0]
       var rel = paramsplit[1].replace(/["']/g, '')
-      rels[rel] = href
+      if (!rels[rel]) {
+        rels[rel] = []
+      }
+      rels[rel].push(href)
+      if (rels[rel].length > 1) {
+        rels[rel].sort()
+      }
     }
   }
   return rels

--- a/lib/web.js
+++ b/lib/web.js
@@ -17,6 +17,22 @@ var XMLHttpRequest = require('./util/xhr')
  */
 var SolidWebClient = {
   /**
+   * Creates and returns the appropriate Solid wrapper for the XHR response.
+   * @method createResponse
+   * @param xhrResponse {XMLHttpRequest} XHR Response
+   * @param method {String} HTTP verb
+   * @returns {SolidResponse|SolidContainer} Either a SolidResponse or a
+   *   SolidContainer instance.
+   */
+  createResponse: function createResponse (xhrResponse, method) {
+    var response = new SolidResponse(xhrResponse, method)
+    if (response.method === 'get' && response.isContainer()) {
+      return new SolidContainer(response.location, response)
+    }
+    return response
+  },
+
+  /**
    * Returns the current window's location (for use with `needsProxy()`)
    * if used in browser, or `null` if used from Node.
    * @method currentUrl
@@ -82,6 +98,7 @@ var SolidWebClient = {
     if (this.needsProxy(url) || options.forceProxy) {
       url = this.proxyUrl(url)
     }
+    var webClient = this
     return new Promise(function (resolve, reject) {
       var http = new XMLHttpRequest()
       http.open(method, url)
@@ -95,8 +112,8 @@ var SolidWebClient = {
         http.timeout = options.timeout
       }
       http.onload = function () {
-        if (this.status >= 200 && this.status < 300) {
-          resolve(new SolidResponse(this, method))
+        if (this.status >= 200 && this.status < 400) {
+          resolve(webClient.createResponse(this, method))
         } else {
           reject({
             status: this.status,
@@ -141,20 +158,31 @@ var SolidWebClient = {
    *          CORS Requests.
    * @param [options.timeout=config.timeout] {Number} Request timeout in
    *          milliseconds.
-   * @return {Promise<SolidResponse>|Object} Result of the HTTP GET operation
+   * @return {Promise<SolidResponse|SolidContainer>|Object} Result of the HTTP
+   *   GET operation, or an error object
    */
   get: function get (url, options) {
+    options = options || {}
+    options.headers = options.headers || {}
+    // If no explicit Accept: header specified, set one
+    if (!options.headers['Accept']) {
+      options.headers['Accept'] =
+        'text/turtle;q=0.8,*/*;q=0.5'
+    }
     return this.solidRequest(url, 'GET', options)
   },
 
   /**
-   * Lists the contents of a Solid Container
+   * Lists the contents of a Solid Container.
+   * (Deprecated, use `web.get()` instead.)
    * @method list
+   * @deprecated
    * @param url {String} Url of the container to list
    * @param [options] Options hashmap, see docs for `solidResponse()`
    * @return {Promise<SolidContainer>}
    */
   list: function list (url, options) {
+    console.warn('web.list() is deprecated. Use web.get() instead.')
     if (typeof url !== 'string') {
       throw new Error('Invalid url passed to list()')
     }

--- a/test/unit/solid-container-test.js
+++ b/test/unit/solid-container-test.js
@@ -23,6 +23,7 @@ function sampleResponse () {
 test('SolidContainer empty container test', function (t) {
   let container = new SolidContainer()
   t.ok(container.isEmpty(), 'Empty container - isEmpty() true')
+  t.ok(container.isContainer(), 'Container - isContainer() true')
   t.notOk(container.uri, 'Empty container - null uri')
   t.notOk(container.parsedGraph, 'Empty container - null parsedGraph')
   t.deepEqual(container.contentsUris, [],

--- a/test/unit/solid-response-test.js
+++ b/test/unit/solid-response-test.js
@@ -4,12 +4,13 @@ var test = require('tape')
 var SolidResponse = require('../../lib/solid/response')
 
 test('empty SolidResponse test', function (t) {
-  t.plan(4)
   let response = new SolidResponse()
+  t.notOk(response.isContainer(), 'An empty response is not a Container')
   t.notOk(response.xhr, 'An empty response should have an empty .xhr property')
   t.notOk(response.user, 'An empty response should not have the user set')
   t.notOk(response.isLoggedIn(), 'User should not be logged in')
   t.notOk(response.exists(), 'Resource should not exist for empty header')
+  t.end()
 })
 
 test('SolidResponse user.isLoggedIn test', function (t) {

--- a/test/unit/web-util-test.js
+++ b/test/unit/web-util-test.js
@@ -17,11 +17,14 @@ test('web-util.composePatchQuery() test', function (t) {
 
 test('parse link header test', function (t) {
   t.plan(1)
-  let linkStr = '<testResource.ttl.acl>; rel="acl", <testResource.ttl.meta>; rel="describedBy", <http://www.w3.org/ns/ldp#Resource>; rel="type"'
+  let linkStr = '<testResource.ttl.acl>; rel="acl", <testResource.ttl.meta>; rel="describedBy", <http://www.w3.org/ns/ldp#Resource>; rel="type", <http://www.w3.org/ns/ldp#RDFResource>; rel="type"'
   let expectedParsedLinks = {
-    acl: 'testResource.ttl.acl',
-    describedBy: 'testResource.ttl.meta',
-    type: 'http://www.w3.org/ns/ldp#Resource'
+    acl: [ 'testResource.ttl.acl' ],
+    describedBy: [ 'testResource.ttl.meta' ],
+    type: [
+      'http://www.w3.org/ns/ldp#RDFResource',
+      'http://www.w3.org/ns/ldp#Resource'
+    ]
   }
   let actualParsedLinks = webUtil.parseLinkHeader(linkStr)
 


### PR DESCRIPTION
Fixes issue #72.

* Refactors `web.get()` to include the functionality of `list()`. That is, if the result
  of a `get()` is a container, returns an instance of `SolidContainer` like `list()` does,
  and otherwise returns the usual `SolidResponse` instance.
* Adds an `isContainer()` convenience method to `SolidResponse`.
* Also, fixes the type parsing logic (was only parses one type, out of several)