### PR TITLE
Webid discovery

### DIFF
--- a/lib/identity.js
+++ b/lib/identity.js
@@ -3,12 +3,48 @@
  * Provides Solid helper functions involved with parsing a user's WebId profile.
  * @module identity
  */
+module.exports.discoverWebID = discoverWebID
 module.exports.getProfile = getProfile
 module.exports.loadExtendedProfile = loadExtendedProfile
 
 var graphUtil = require('./util/graph-util')
 var webClient = require('./web')
 var SolidProfile = require('./solid/profile')
+var vocab = require('./vocab')
+
+/**
+ * Discovers a user's WebId (URL) starting from the account/domain URL
+ * @method discoverWebID
+ * @param url {String} Location of a user's account or domain.
+ * @throw {Error} Reason why the WebID could not be discovered
+ * @return {Promise<uri>}
+ */
+
+function discoverWebID (url) {
+  return new Promise(function (resolve) {
+    webClient.options(url)
+      .then(function (meta) {
+        var metaUrl = meta.meta
+        if (metaUrl) {
+          webClient.getParsedGraph(metaUrl)
+            .then(function (graph) {
+              var webid = graph.any(undefined, vocab.foaf('account'))
+              if (webid && webid.uri) {
+                resolve(webid.uri)
+              } else {
+                throw new Error('Could not find a WebID matching the domain ' +
+                url)
+              }
+            })
+        } else {
+          throw new Error('Could not find a meta URL in the Link header')
+        }
+      })
+      .catch(function (err) {
+        throw new Error('Could not complete request.', err)
+      })
+  })
+}
 
 /**
  * Fetches a user's WebId profile, optionally follows `sameAs` etc links,

--- a/lib/identity.js
+++ b/lib/identity.js
@@ -8,6 +8,7 @@ module.exports.getProfile = getProfile
 module.exports.loadExtendedProfile = loadExtendedProfile
 
 var graphUtil = require('./util/graph-util')
+var webUtil = require('./util/web-util')
 var webClient = require('./web')
 var SolidProfile = require('./solid/profile')
 var vocab = require('./vocab')
@@ -21,11 +22,12 @@ var vocab = require('./vocab')
  */
 
 function discoverWebID (url) {
-  return new Promise(function (resolve) {
+  return new Promise(function (resolve, reject) {
     webClient.options(url)
       .then(function (meta) {
         var metaUrl = meta.meta
         if (metaUrl) {
+          metaUrl = webUtil.absoluteUrl(metaUrl, url)
           webClient.getParsedGraph(metaUrl)
             .then(function (graph) {
               var webid = graph.any(undefined, vocab.foaf('account'))
@@ -36,12 +38,15 @@ function discoverWebID (url) {
                 url)
               }
             })
+            .catch(function (err) {
+              reject(err)
+            })
         } else {
           throw new Error('Could not find a meta URL in the Link header')
         }
       })
       .catch(function (err) {
-        throw new Error('Could not complete request.', err)
+        reject(err)
       })
   })
 }

--- a/lib/util/web-util.js
+++ b/lib/util/web-util.js
@@ -87,7 +87,6 @@ function parseLinkHeader (link) {
 function composePatchQuery (toDel, toIns) {
   var query = ''
 
-  var i
   if (toDel && toDel.length > 0) {
     toDel = toDel.map(function (each) {
       if (each.endsWith('.')) {

--- a/lib/util/web-util.js
+++ b/lib/util/web-util.js
@@ -6,6 +6,7 @@
 module.exports.composePatchQuery = composePatchQuery
 module.exports.parseAllowedMethods = parseAllowedMethods
 module.exports.parseLinkHeader = parseLinkHeader
+module.exports.absoluteUrl = absoluteUrl
 
 /**
  * Extracts the allowed HTTP methods from the 'Allow' and 'Accept-Patch'
@@ -75,6 +76,20 @@ function parseLinkHeader (link) {
     }
   }
   return rels
+}
+
+/**
+* Return an absolute URL
+* @method absoluteUrl
+* @param url {String} Absolute or relative URL
+* @param base {String} URL to be used as base
+* @return {String}
+*/
+function absoluteUrl (linkUrl, baseUrl) {
+  if (linkUrl && linkUrl.slice(0, 4) !== 'http') {
+    linkUrl = baseUrl.slice(0, baseUrl.lastIndexOf('/') + 1) + linkUrl
+  }
+  return linkUrl
 }
 
 /**


### PR DESCRIPTION
Add discovery of WebID from domain name.

1) Send an OPTIONS request to the account URL (domain name) -- i.e. https://user.example.org
2) GET the meta URL retrieved from 1) -- i.e. https://user.example.org/.meta
3) Return the WebID found in a `foaf:account` triple in the meta document