### PR TITLE
Init typeregistry

### DIFF
--- a/README.md
+++ b/README.md
@@ -426,7 +426,7 @@ solid.web.get(url)
       // Regular resource
       console.log('Raw resource: %s', response.raw())
 
-      // You can parse it using RDFLib.js, etc:
+      // You can access the parsed graph (parsed by RDFLib.js):
       var parsedGraph = response.parsedGraph()
     }
   })

--- a/index.js
+++ b/index.js
@@ -51,6 +51,7 @@ var Solid = {
   rdflib: (typeof $rdf !== 'undefined') ? $rdf : require('rdflib'),
   signup: require('./lib/auth').signup,
   status: require('./lib/status'),
+  typeRegistry: require('./lib/type-registry'),
   util: require('./lib/util/web-util'),
   vocab: require('./lib/vocab'),
   web: require('./lib/web')

--- a/index.js
+++ b/index.js
@@ -51,6 +51,7 @@ var Solid = {
   rdflib: (typeof $rdf !== 'undefined') ? $rdf : require('rdflib'),
   signup: require('./lib/auth').signup,
   status: require('./lib/status'),
+  util: require('./lib/util/web-util'),
   vocab: require('./lib/vocab'),
   web: require('./lib/web')
 }

--- a/lib/solid/profile.js
+++ b/lib/solid/profile.js
@@ -197,16 +197,19 @@ SolidProfile.prototype.appendFromGraph =
 
 /**
  * Returns the value of a given "field" (predicate) from the profile's parsed
- * graph. Note: If there are more than one matches for this predicate, .find()
- * returns the first one.
+ * graph. If there are more than one matches for this predicate, .find()
+ * returns the first one. If there are no matches, `null` is returned.
  * Usage:
  *
  *   ```
  *   var inboxUrl = profile.find(vocab.solid('inbox'))
+ *   if (inboxUrl) {
+ *     console.log('Inbox is located at:', inboxUrl)
+ *   }
  *   ```
  * @method find
  * @param predicate {NamedNode} RDF named node of the predicate
- * @return {String} String value (or uri)
+ * @return {String|Null} String value (or uri)
  */
 SolidProfile.prototype.find = function find (predicate) {
   if (!this.parsedGraph) {
@@ -214,7 +217,10 @@ SolidProfile.prototype.find = function find (predicate) {
   }
   var subject = rdf.sym(this.webId)
   var result = this.parsedGraph.any(subject, predicate)
-  return result ? (result.value || result.uri) : undefined
+  if (!result) {
+    return result
+  }
+  return result.value || result.uri
 }
 
 /**

--- a/lib/solid/profile.js
+++ b/lib/solid/profile.js
@@ -9,6 +9,8 @@ var typeRegistry = require('../type-registry')
 var graphUtil = require('../util/graph-util')
 var parseLinks = graphUtil.parseLinks
 
+var PREFERENCES_DEFAULT_URI = '/preferences/prefs.ttl'
+
 /**
  * Provides convenience methods for a WebID Profile.
  * Used by `identity.getProfile()`
@@ -75,7 +77,7 @@ function SolidProfile (profileUrl, parsedProfile, response) {
   this.parsedGraph = null
   /**
    * Profile preferences object (link and parsed graph).
-   * Is considered a part of the 'Extended Profile'
+   * Currently used as a 'Private Profile', and is part of the Extended Profile.
    * @property preferences
    * @type Object
    */
@@ -278,9 +280,40 @@ SolidProfile.prototype.relatedProfilesLinks = function relatedProfilesLinks () {
  * @return {Boolean}
  */
 SolidProfile.prototype.hasStorage = function hasStorage () {
-  return this.storage &&
-    this.storage.length > 0
+  return this.storage && this.storage.length > 0
 }
+
+/**
+ * Returns whether or not the profile has a private (unlisted) Type Index
+ * Registry associated with it (linked to from the profile document).
+ * @method hasTypeRegistryPrivate
+ * @throws {Error} If the profile has not been loaded (via getProfile()).
+ * @return {Boolean} Returns truthy value if the private (unlisted) type index
+ *   registry exists (that is, has a link in the profile).
+ */
+SolidProfile.prototype.hasTypeRegistryPrivate =
+  function hasTypeRegistryPrivate () {
+    if (!this.isLoaded) {
+      throw new Error('Must load profile before checking if registry exists.')
+    }
+    return this.typeIndexUnlisted.uri
+  }
+
+/**
+ * Returns whether or not the profile has a public (listed) Type Index Registry
+ * associated with it (linked to from the profile document).
+ * @method hasTypeRegistryPublic
+ * @throws {Error} If the profile has not been loaded (via getProfile()).
+ * @return {Boolean} Returns truthy value if the public (listed) type index
+ *   registry exists (that is, has a link in the profile).
+ */
+SolidProfile.prototype.hasTypeRegistryPublic =
+  function hasTypeRegistryPublic () {
+    if (!this.isLoaded) {
+      throw new Error('Must load profile before checking if registry exists.')
+    }
+    return this.typeIndexListed.uri
+  }
 
 /**
  * Convenience method to load the type index registry. Usage:
@@ -293,7 +326,7 @@ SolidProfile.prototype.hasStorage = function hasStorage () {
  *   ```
  * @method loadTypeRegistry
  * @param [options] Options hashmap (see Solid.web.solidRequest() function docs)
- * @return {SolidProfile}
+ * @return {Promise<SolidProfile>}
  */
 SolidProfile.prototype.loadTypeRegistry = function loadTypeRegistry (options) {
   return typeRegistry.loadTypeRegistry(this, options)
@@ -301,8 +334,9 @@ SolidProfile.prototype.loadTypeRegistry = function loadTypeRegistry (options) {
 
 /**
  * Adds a parsed type index graph to the appropriate type registry (public
- *   or private).
+ *   or private). (Used when parsing the extended profile).
  * @method addTypeRegistry
+ * @private
  * @param graph {$rdf.IndexedFormula} Parsed graph (loaded from a type index
  *   resource)
  * @param uri {String} Location of the type registry index document
@@ -334,6 +368,31 @@ SolidProfile.prototype.typeRegistryForClass =
   function typeRegistryForClass (rdfClass) {
     return typeRegistry.typeRegistryForClass(this, rdfClass)
   }
+
+/**
+ * Returns the default location of the container in which the Type Registry
+ * Index resources will reside. (Uses the same container as the profile
+ * document.)
+ * @method typeRegistryDefaultUri
+ * @return {String}
+ */
+SolidProfile.prototype.typeRegistryDefaultUri =
+  function typeRegistryDefaultUri () {
+    return this.webId.replace(/\\/g, '/').replace(/\/[^\/]*\/?$/, '') + '/'
+  }
+
+/**
+ * Returns the relative URL of the private profile (preferences) resource.
+ * @method privateProfileUri
+ * @return {String}
+ */
+SolidProfile.prototype.privateProfileUri = function privateProfileUri () {
+  if (this.preferences && this.preferences.uri) {
+    return this.preferences.uri
+  } else {
+    return PREFERENCES_DEFAULT_URI
+  }
+}
 
 /**
  * Registers a given RDF class in the user's type index registries, so that

--- a/lib/solid/profile.js
+++ b/lib/solid/profile.js
@@ -9,7 +9,8 @@ var typeRegistry = require('../type-registry')
 var graphUtil = require('../util/graph-util')
 var parseLinks = graphUtil.parseLinks
 
-var PREFERENCES_DEFAULT_URI = '/preferences/prefs.ttl'
+var PREFERENCES_DEFAULT_URI = '/settings/prefs.ttl'
+var PROFILE_CONTAINER_DEFAULT_URI = '/profile/'
 
 /**
  * Provides convenience methods for a WebID Profile.
@@ -365,6 +366,27 @@ SolidProfile.prototype.addTypeRegistry = function addTypeRegistry (graph, uri) {
 }
 
 /**
+ * Reloads the contents of the profile's Type Index registries.
+ * @method reloadTypeRegistry
+ * @return {Promise<SolidProfile>}
+ */
+SolidProfile.prototype.reloadTypeRegistry = function reloadTypeRegistry () {
+  this.resetTypeRegistry()
+  return this.loadTypeRegistry()
+}
+
+/**
+ * Resets the contents (graphs) of the profile's Type Index registries to null.
+ * Used internally by `reloadTypeRegistry()`.
+ * @method resetTypeRegistry
+ * @private
+ */
+SolidProfile.prototype.resetTypeRegistry = function resetTypeRegistry () {
+  this.typeIndexListed.graph = null
+  this.typeIndexUnlisted.graph = null
+}
+
+/**
  * Returns lists of registry entries for a given RDF Class.
  * @method typeRegistryForClass
  * @param rdfClass {rdf.NamedNode} RDF Class symbol
@@ -384,7 +406,14 @@ SolidProfile.prototype.typeRegistryForClass =
  */
 SolidProfile.prototype.typeRegistryDefaultUri =
   function typeRegistryDefaultUri () {
-    return this.webId.replace(/\\/g, '/').replace(/\/[^\/]*\/?$/, '') + '/'
+    var profileUri = this.webId || this.baseProfileUrl
+    var baseContainer
+    if (profileUri) {
+      baseContainer = profileUri.replace(/\\/g, '/').replace(/\/[^\/]*\/?$/, '') + '/'
+    } else {
+      baseContainer = PROFILE_CONTAINER_DEFAULT_URI
+    }
+    return baseContainer
   }
 
 /**

--- a/lib/solid/response.js
+++ b/lib/solid/response.js
@@ -142,7 +142,7 @@ SolidResponse.prototype.aclAbsoluteUrl = function aclAbsoluteUrl () {
   if (!this.acl) {
     return this.acl
   }
-  var aclAbsoluteUrl = webUtil.absoluteUrl(this.acl, this.url)
+  var aclAbsoluteUrl = webUtil.absoluteUrl(this.url, this.acl)
   return aclAbsoluteUrl
 }
 
@@ -206,7 +206,7 @@ SolidResponse.prototype.metaAbsoluteUrl = function metaAbsoluteUrl () {
   if (!this.meta) {
     return this.meta
   }
-  var metaAbsoluteUrl = webUtil.absoluteUrl(this.meta, this.url)
+  var metaAbsoluteUrl = webUtil.absoluteUrl(this.url, this.meta)
   return metaAbsoluteUrl
 }
 

--- a/lib/type-registry.js
+++ b/lib/type-registry.js
@@ -452,6 +452,7 @@ function removeFromTypeIndex (profile, rdfClass, isListed, location) {
  *   index). Defaults to `false` (unlisted).
  * @param [location] {String} If present, only unregister the class from this
  *   location (absolute URI).
+ * @throws {Error}
  * @return {Promise<SolidProfile>}
  */
 function unregisterType (profile, rdfClass, isListed, location) {

--- a/lib/type-registry.js
+++ b/lib/type-registry.js
@@ -4,26 +4,159 @@
  * Registry files, and with registering resources with them.
  * @module type-registry
  */
-module.exports.loadTypeRegistry = loadTypeRegistry
+module.exports.blankPrivateTypeIndex = blankPrivateTypeIndex
+module.exports.blankPublicTypeIndex = blankPublicTypeIndex
+module.exports.initTypeRegistryPrivate = initTypeRegistryPrivate
+module.exports.initTypeRegistryPublic = initTypeRegistryPublic
 module.exports.isUnlistedTypeIndex = isUnlistedTypeIndex
 module.exports.isListedTypeIndex = isListedTypeIndex
+module.exports.loadTypeRegistry = loadTypeRegistry
 module.exports.registerType = registerType
-module.exports.unregisterType = unregisterType
 module.exports.typeRegistryForClass = typeRegistryForClass
+module.exports.unregisterType = unregisterType
 
 // var graphUtil = require('./util/graph-util')
 var IndexRegistration = require('./solid/index-registration')
 var rdf = require('./util/rdf-parser').rdflib
 var webClient = require('./web')
 // var SolidProfile = require('./solid/profile')
+var util = require('./util/web-util.js')
+var graphUtil = require('./util/graph-util.js')
 var vocab = require('./vocab')
 
 /**
- * Adds an RDF class to a user's type index registry.
- * Called by `registerTypeIndex()`, which does all the argument validation.
+ * Returns a blank private type index registry option.
+ * For use with `initTypeRegistry()`.
+ * @method blankPrivateTypeIndex
+ * @private
+ * @return {Object} Blank type index registry object
+ */
+function blankPrivateTypeIndex () {
+  var thisDoc = rdf.sym('')
+  var indexStatements = [
+    rdf.st(thisDoc, vocab.rdf('type'), vocab.solid('TypeIndex')),
+    rdf.st(thisDoc, vocab.rdf('type'), vocab.solid('UnlistedDocument'))
+  ]
+  var publicIndex = {
+    data: graphUtil.serializeStatements(indexStatements),
+    graph: graphUtil.graphFromStatements(indexStatements),
+    slug: 'privateTypeIndex.ttl',
+    uri: null  // actual url not yet known
+  }
+  return publicIndex
+}
+
+/**
+ * Returns a blank public type index registry option.
+ * For use with `initTypeRegistry()`.
+ * @method blankPublicTypeIndex
+ * @private
+ * @return {Object} Blank type index registry object
+ */
+function blankPublicTypeIndex () {
+  var thisDoc = rdf.sym('')
+  var indexStatements = [
+    rdf.st(thisDoc, vocab.rdf('type'), vocab.solid('TypeIndex')),
+    rdf.st(thisDoc, vocab.rdf('type'), vocab.solid('ListedDocument'))
+  ]
+  var publicIndex = {
+    data: graphUtil.serializeStatements(indexStatements),
+    graph: graphUtil.graphFromStatements(indexStatements),
+    slug: 'publicTypeIndex.ttl',
+    uri: null  // actual url not yet known
+  }
+  return publicIndex
+}
+
+/**
+ * Initializes the private Type Index Registry resource, updates
+ * the profile with the initialized index, and returns the updated profile.
+ * @method initTypeRegistryPrivate
  * @param profile {SolidProfile} User's WebID profile
- * @param rdfClass {rdf.NamedNode} Type to register in the index.
- * @param location {String} Absolute URI  to the location you want the class
+ * @param [options] Options hashmap (see solid.web.solidRequest() function docs)
+ * @return {Promise<SolidProfile>} Resolves with the updated profile instance.
+ */
+function initTypeRegistryPrivate (profile, options) {
+  var registryContainerUri = profile.typeRegistryDefaultUri()
+  var webId = rdf.sym(profile.webId)
+  var privateIndex = blankPrivateTypeIndex()
+  // First, create the private Type Index Registry resource
+  return webClient.post(registryContainerUri, privateIndex.data,
+                        privateIndex.slug, options)
+    .catch(function (err) {
+      throw new Error('Could not create privateIndex document:', err)
+    })
+    .then(function (response) {
+      // Private type index resource created.
+      // Update the private profile (preferences) to link to it.
+      privateIndex.uri = util.absoluteUrl(registryContainerUri, response.url)
+      var toAdd = [
+        rdf.st(webId, vocab.solid('privateTypeIndex'), rdf.sym(privateIndex.uri))
+      ]
+      var toDel = []
+      // Note: this PATCH will actually create a private profile if it doesn't
+      // already exist.
+      return webClient.patch(profile.privateProfileUri(), toDel, toAdd, options)
+    })
+    .catch(function (err) {
+      throw new Error('Could not update profile with private index:' + err)
+    })
+    .then(function (response) {
+      // Profile successfully patched with a link to the created private index
+      // It's safe to update this instance of profile
+      profile.typeIndexUnlisted = privateIndex
+      // Finally, return the updated profile with type index loaded
+      return profile
+    })
+}
+
+/**
+ * Initializes the public Type Index Registry resource, updates
+ * the profile with the initialized index, and returns the updated profile.
+ * @method initTypeRegistryPublic
+ * @param profile {SolidProfile} User's WebID profile
+ * @param [options] Options hashmap (see solid.web.solidRequest() function docs)
+ * @return {Promise<SolidProfile>} Resolves with the updated profile instance.
+ */
+function initTypeRegistryPublic (profile, options) {
+  var registryContainerUri = profile.typeRegistryDefaultUri()
+  var webId = rdf.sym(profile.webId)
+  var publicIndex = blankPublicTypeIndex()
+  // First, create the public Type Index Registry resource
+  return webClient.post(registryContainerUri, publicIndex.data,
+                        publicIndex.slug, options)
+    .catch(function (err) {
+      throw new Error('Could not create publicIndex document:', err)
+    })
+    .then(function (response) {
+      // Public type index resource created. Update the profile to link to it.
+      publicIndex.uri = util.absoluteUrl(registryContainerUri, response.url)
+      var toAdd = [
+        rdf.st(webId, vocab.solid('publicTypeIndex'), rdf.sym(publicIndex.uri))
+      ]
+      var toDel = []
+      return webClient.patch(profile.webId, toDel, toAdd, options)
+    })
+    .catch(function (err) {
+      throw new Error('Could not update profile with public index:', err)
+    })
+    .then(function (response) {
+      // Profile successfully patched with a link to the created public index
+      // It's safe to update this instance of profile
+      profile.typeIndexListed = publicIndex
+      // Finally, return the updated profile with type index loaded
+      return profile
+    })
+}
+
+/**
+ * Adds an RDF class to a user's type index registry, and returns the
+ * profile (with the appropriate type registry index updated).
+ * Called by `registerTypeIndex()`, which does all the argument validation.
+ * @method addToTypeIndex
+ * @param profile {SolidProfile} User's WebID profile
+ * @param rdfClass {NamedNode} RDF type to register in the index.
+ * @param location {String} Absolute URI to the location you want the class
  *   registered to.
  * @param locationType {String} Either 'instance' or 'container'
  * @param isListed {Boolean} Whether to register in a listed or unlisted index).
@@ -36,10 +169,13 @@ function addToTypeIndex (profile, rdfClass, location, locationType,
   var hash = require('shorthash')
   var fragmentId = hash.unique(rdfClass.uri)
   var registryUri
+  var registryGraph
   if (isListed) {
     registryUri = profile.typeIndexListed.uri
+    registryGraph = profile.typeIndexListed.graph
   } else {
     registryUri = profile.typeIndexUnlisted.uri
+    registryGraph = profile.typeIndexUnlisted.graph
   }
   if (!registryUri) {
     throw new Error('Cannot register type, registry URL missing')
@@ -51,34 +187,29 @@ function addToTypeIndex (profile, rdfClass, location, locationType,
     locationTypeClass = vocab.solid('instance')
   } else {
     locationTypeClass = vocab.solid('instanceContainer')
+    // Add trailing slash if it's missing and is a container
+    if (location.lastIndexOf('/') !== location.length - 1) {
+      location += '/'
+    }
   }
-  // triples to delete
-  var toDel = null
-  // Assemble the list of triples to add in the PATCH operation
+  // triples to delete (none for the moment)
+  var toDel = []
+  // Create the list of triples to add in the PATCH operation
   var toAdd = [
-    // <#ab09fd> a solid:TypeRegistration;
-    rdf.st(
-      registrationUri,
-      vocab.rdf('type'),
-      vocab.solid('TypeRegistration')
-    ).toNT(),
-    // solid:forClass sioc:Post;
-    rdf.st(
-      registrationUri,
-      vocab.solid('forClass'),
-      rdfClass
-    ).toNT(),
-    // solid:instanceContainer </posts/>.
-    rdf.st(
-      registrationUri,
-      locationTypeClass,
-      rdf.sym(location)
-    ).toNT()
+    // example: '<#ab09fd> a solid:TypeRegistration;'
+    rdf.st(registrationUri, vocab.rdf('type'), vocab.solid('TypeRegistration')),
+    // example: 'solid:forClass sioc:Post;'
+    rdf.st(registrationUri, vocab.solid('forClass'), rdfClass),
+    // example: 'solid:instanceContainer </posts/>.'
+    rdf.st(registrationUri, locationTypeClass, rdf.sym(location))
   ]
   return webClient.patch(registryUri, toDel, toAdd)
-    .then(function () {
-      // Update the registry, to reflect new state
-      return profile.loadTypeRegistry()
+    .then(function (response) {
+      // Update the profile object with the new registry without reloading
+      if (!registryGraph) {
+        registryGraph = graphUtil.graphFromStatements(toAdd)
+      }
+      return profile
     })
 }
 
@@ -152,6 +283,7 @@ function loadTypeRegistry (profile, options) {
 /**
  * Registers a given RDF class in the user's type index registries, so that
  * other applications can discover it.
+ * Note: If the relevant type index registry does not exist, it will be created.
  * @method registerType
  * @param profile {SolidProfile} Loaded WebID profile
  * @param rdfClass {rdf.NamedNode} Type to register in the index.
@@ -162,7 +294,7 @@ function loadTypeRegistry (profile, options) {
  *   defaults to 'container'
  * @param [isListed=false] {Boolean} Whether to register in a listed or unlisted
  *   index). Defaults to `false` (unlisted).
- * @return {Promise<SolidProfile>}
+ * @return {Promise<SolidProfile>} Resolves with the updated profile.
  */
 function registerType (profile, rdfClass, location, locationType, isListed) {
   if (!profile) {
@@ -180,12 +312,19 @@ function registerType (profile, rdfClass, location, locationType, isListed) {
   }
   return loadTypeRegistry(profile)  // make sure type registry is loaded
     .then(function (profile) {
-      if (isListed && !profile.typeIndexListed.graph) {
-        throw new Error('Profile has no Listed type index')
+      if (isListed && !profile.hasTypeRegistryPublic()) {
+        // Public type registry is needed, but doesn't exist. Create it.
+        return initTypeRegistryPublic(profile)
       }
-      if (!isListed && !profile.typeIndexUnlisted.graph) {
-        throw new Error('Profile has no Unlisted type index')
+      if (!isListed && !profile.hasTypeRegistryPrivate()) {
+        // Private type registry is needed, but doesn't exist. Create it.
+        return initTypeRegistryPrivate(profile)
       }
+      // Relevant type registry exists, proceed
+      return profile
+    })
+    .then(function (profile) {
+      // Made sure the relevant type registry exists, and can now add to it
       return addToTypeIndex(profile, rdfClass, location, locationType,
         isListed)
     })
@@ -204,9 +343,11 @@ function typeRegistryForClass (profile, rdfClass) {
 
   return registrations
     .concat(
+      // Public/listed registrations
       registrationsFromGraph(profile.typeIndexListed.graph, rdfClass, isListed)
     )
     .concat(
+      // Private/unlisted registrations
       registrationsFromGraph(profile.typeIndexUnlisted.graph, rdfClass,
         !isListed)
     )
@@ -221,51 +362,31 @@ function typeRegistryForClass (profile, rdfClass) {
  * @return {Array<IndexRegistration>}
  */
 function registrationsFromGraph (graph, rdfClass, isListed) {
-  var entrySubject
-  var location
+  var entrySubject, instanceMatches, containerMatches
   var registrations = []
   if (!graph) {
     return registrations
   }
-
   var matches = graph.statementsMatching(null, null, rdfClass)
   matches.forEach(function (match) {
     entrySubject = match.subject
     // Have the hash fragment of the registration, now need to determine
     // location type, and the actual location.
-    location = graph.any(entrySubject, vocab.solid('instance'))
-    if (location) {
+    instanceMatches =
+      graph.statementsMatching(entrySubject, vocab.solid('instance'))
+    instanceMatches.forEach(function (location) {
       registrations.push(new IndexRegistration(entrySubject.uri, rdfClass,
-        'instance', location.uri, isListed))
-    }
+        'instance', location.object.uri, isListed))
+    })
     // Now try to find solid:instanceContainer matches
-    location = graph.any(entrySubject, vocab.solid('instanceContainer'))
-    if (location) {
+    containerMatches =
+      graph.statementsMatching(entrySubject, vocab.solid('instanceContainer'))
+    containerMatches.forEach(function (location) {
       registrations.push(new IndexRegistration(entrySubject.uri, rdfClass,
-        'container', location.uri, isListed))
-    }
+        'container', location.object.uri, isListed))
+    })
   })
   return registrations
-}
-
-/**
- * Returns a list of statements related to a given registry entry, to remove
- * them via PATCH, see `removeFromTypeIndex()`.
- * @param registryGraph {$rdf.IndexedFormula} Type index registry graph
- * @param registration {IndexRegistration} Type index registry entry to generate
- *   statements from.
- * @return {Array<String>} List of statements (in "canonical" string format)
- *   related to the registry.
- */
-function registryTriplesFor (registryGraph, registration) {
-  var statements = []
-  // Return all statements related to the registry entry (that have it as
-  // the subject)
-  registryGraph.statementsMatching(rdf.sym(registration.registrationUri))
-    .forEach(function (match) {
-      statements.push(match.toNT())
-    })
-  return statements
 }
 
 /**
@@ -295,9 +416,7 @@ function removeFromTypeIndex (profile, rdfClass, isListed, location) {
   var registrations = registrationsFromGraph(registryGraph, rdfClass, isListed)
   if (registrations.length === 0) {
     // No existing registrations, no need to do anything, just return profile
-    return new Promise(function (resolve, reject) {
-      resolve(profile)
-    })
+    return Promise.resolve(profile)
   }
   if (location) {
     // If location is present, filter the to-remove list only to registrations
@@ -309,7 +428,10 @@ function removeFromTypeIndex (profile, rdfClass, isListed, location) {
   // Generate triples to delete
   var toDel = []
   registrations.forEach(function (registration) {
-    toDel = toDel.concat(registryTriplesFor(registryGraph, registration))
+    registryGraph.statementsMatching(rdf.sym(registration.registrationUri))
+      .forEach(function (statement) {
+        toDel.push(statement)
+      })
   })
   // Nothing to add
   var toAdd = []

--- a/lib/type-registry.js
+++ b/lib/type-registry.js
@@ -22,6 +22,7 @@ var webClient = require('./web')
 // var SolidProfile = require('./solid/profile')
 var util = require('./util/web-util.js')
 var graphUtil = require('./util/graph-util.js')
+var webUtil = require('./util/web-util.js')
 var vocab = require('./vocab')
 
 /**
@@ -77,19 +78,21 @@ function blankPublicTypeIndex () {
  * @return {Promise<SolidProfile>} Resolves with the updated profile instance.
  */
 function initTypeRegistryPrivate (profile, options) {
+  options = options || {}
   var registryContainerUri = profile.typeRegistryDefaultUri()
   var webId = rdf.sym(profile.webId)
   var privateIndex = blankPrivateTypeIndex()
   // First, create the private Type Index Registry resource
   return webClient.post(registryContainerUri, privateIndex.data,
-                        privateIndex.slug, options)
+                        privateIndex.slug)
     .catch(function (err) {
       throw new Error('Could not create privateIndex document:', err)
     })
     .then(function (response) {
       // Private type index resource created.
       // Update the private profile (preferences) to link to it.
-      privateIndex.uri = util.absoluteUrl(registryContainerUri, response.url)
+      privateIndex.uri = util.absoluteUrl(webUtil.hostname(registryContainerUri),
+        response.url)
       var toAdd = [
         rdf.st(webId, vocab.solid('privateTypeIndex'), rdf.sym(privateIndex.uri))
       ]
@@ -119,18 +122,20 @@ function initTypeRegistryPrivate (profile, options) {
  * @return {Promise<SolidProfile>} Resolves with the updated profile instance.
  */
 function initTypeRegistryPublic (profile, options) {
+  options = options || {}
   var registryContainerUri = profile.typeRegistryDefaultUri()
   var webId = rdf.sym(profile.webId)
   var publicIndex = blankPublicTypeIndex()
   // First, create the public Type Index Registry resource
   return webClient.post(registryContainerUri, publicIndex.data,
-                        publicIndex.slug, options)
+                        publicIndex.slug)
     .catch(function (err) {
       throw new Error('Could not create publicIndex document:', err)
     })
     .then(function (response) {
       // Public type index resource created. Update the profile to link to it.
-      publicIndex.uri = util.absoluteUrl(registryContainerUri, response.url)
+      publicIndex.uri = util.absoluteUrl(webUtil.hostname(registryContainerUri),
+        response.url)
       var toAdd = [
         rdf.st(webId, vocab.solid('publicTypeIndex'), rdf.sym(publicIndex.uri))
       ]
@@ -206,8 +211,11 @@ function addToTypeIndex (profile, rdfClass, location, locationType,
   return webClient.patch(registryUri, toDel, toAdd)
     .then(function (response) {
       // Update the profile object with the new registry without reloading
-      if (!registryGraph) {
-        registryGraph = graphUtil.graphFromStatements(toAdd)
+      var newRegistration = graphUtil.graphFromStatements(toAdd)
+      if (registryGraph) {
+        graphUtil.appendGraph(registryGraph, newRegistration)
+      } else {
+        registryGraph = newRegistration
       }
       return profile
     })
@@ -438,7 +446,7 @@ function removeFromTypeIndex (profile, rdfClass, isListed, location) {
   return webClient.patch(registryUri, toDel, toAdd)
     .then(function (result) {
       // Update the registry, to reflect new state
-      return profile.loadTypeRegistry()
+      return profile.reloadTypeRegistry()
     })
 }
 

--- a/lib/util/graph-util.js
+++ b/lib/util/graph-util.js
@@ -7,6 +7,9 @@
 module.exports.appendGraph = appendGraph
 module.exports.parseGraph = parseGraph
 module.exports.parseLinks = parseLinks
+module.exports.serializeStatements = serializeStatements
+module.exports.graphFromStatements = graphFromStatements
+module.exports.statementToNT = statementToNT
 
 var rdf = require('./rdf-parser').rdflib
 
@@ -23,6 +26,40 @@ function appendGraph (toGraph, fromGraph, docURI) {
     .forEach(function (st) {
       toGraph.add(st.subject, st.predicate, st.object, st.why)
     })
+}
+
+/**
+ * Converts a statement to string (if it isn't already), optionally slices off
+ * the period at the end, and returns the statement.
+ * @method statementToNT
+ * @param statement {String|Statement} RDF Statement to be converted.
+ * @param [excludeDot=false] {Boolean} Optionally slice off ending period.
+ * @return {String}
+ */
+function statementToNT (statement, excludeDot) {
+  if (typeof statement !== 'string') {
+    // This is an RDF Statement. Convert to string
+    statement = statement.toNT()
+  }
+  if (excludeDot && statement.endsWith('.')) {
+    statement = statement.slice(0, -1)
+  }
+  return statement
+}
+
+/**
+ * Converts a list of RDF statements into an rdflib Graph (Formula), and returns
+ * it.
+ * @method graphFromStatements
+ * @param statements {Array<Statement>}
+ * @return {rdf.Graph}
+ */
+function graphFromStatements (statements) {
+  var graph = rdf.graph()
+  statements.forEach(function (st) {
+    graph.addStatement(st)
+  })
+  return graph
 }
 
 /**
@@ -59,4 +96,17 @@ function parseLinks (graph, subject, predicate, object, source) {
     links[match.object.uri] = true
   })
   return Object.keys(links)
+}
+
+/**
+ * Serializes an array of RDF statements into a simple N-Triples format
+ * suitable for writing to a solid server.
+ * @method serializeStatements
+ * @param statements {Array<Statement>} List of RDF statements
+ * @return {String}
+ */
+function serializeStatements (statements) {
+  var source = statements.map(function (st) { return st.toNT() })
+  source = source.join('\n')
+  return source
 }

--- a/lib/util/graph-util.js
+++ b/lib/util/graph-util.js
@@ -13,6 +13,8 @@ module.exports.statementToNT = statementToNT
 
 var rdf = require('./rdf-parser').rdflib
 
+var ALL_STATEMENTS = null
+
 /**
  * Appends RDF statements from one graph object to another
  * @method appendGraph
@@ -22,7 +24,7 @@ var rdf = require('./rdf-parser').rdflib
  */
 function appendGraph (toGraph, fromGraph, docURI) {
   // var source = (docURI) ? rdf.sym(docURI) : undefined
-  fromGraph.statementsMatching(null, null, null, null)
+  fromGraph.statementsMatching(ALL_STATEMENTS)
     .forEach(function (st) {
       toGraph.add(st.subject, st.predicate, st.object, st.why)
     })

--- a/lib/util/web-util.js
+++ b/lib/util/web-util.js
@@ -7,6 +7,7 @@ module.exports.composePatchQuery = composePatchQuery
 module.exports.parseAllowedMethods = parseAllowedMethods
 module.exports.parseLinkHeader = parseLinkHeader
 module.exports.absoluteUrl = absoluteUrl
+module.exports.hostname = hostname
 
 var graphUtil = require('./graph-util')
 
@@ -78,6 +79,27 @@ function parseLinkHeader (link) {
     }
   }
   return rels
+}
+
+function hostname (url) {
+  var protocol, hostname, result, pathSegments
+  var fragments = url.split('//')
+  if (fragments.length === 2) {
+    protocol = fragments[0]
+    hostname = fragments[1]
+  } else {
+    hostname = url
+  }
+  pathSegments = hostname.split('/')
+  if (protocol) {
+    result = protocol + '//' + pathSegments[0]
+  } else {
+    result = pathSegments[0]
+  }
+  if (url.startsWith('//')) {
+    result = '//' + result
+  }
+  return result
 }
 
 /**

--- a/lib/util/web-util.js
+++ b/lib/util/web-util.js
@@ -8,6 +8,8 @@ module.exports.parseAllowedMethods = parseAllowedMethods
 module.exports.parseLinkHeader = parseLinkHeader
 module.exports.absoluteUrl = absoluteUrl
 
+var graphUtil = require('./graph-util')
+
 /**
  * Extracts the allowed HTTP methods from the 'Allow' and 'Accept-Patch'
  * headers, and returns a hashmap of verbs allowed by the server
@@ -81,42 +83,44 @@ function parseLinkHeader (link) {
 /**
 * Return an absolute URL
 * @method absoluteUrl
-* @param url {String} Absolute or relative URL
-* @param base {String} URL to be used as base
+* @param baseUrl {String} URL to be used as base
+* @param pathUrl {String} Absolute or relative URL
 * @return {String}
 */
-function absoluteUrl (linkUrl, baseUrl) {
-  if (linkUrl && linkUrl.slice(0, 4) !== 'http') {
-    linkUrl = baseUrl.slice(0, baseUrl.lastIndexOf('/') + 1) + linkUrl
+function absoluteUrl (baseUrl, pathUrl) {
+  if (pathUrl && pathUrl.slice(0, 4) !== 'http') {
+    return [baseUrl, pathUrl].map(function (path) {
+      if (path[0] === '/') {
+        path = path.slice(1)
+      }
+      if (path[path.length - 1] === '/') {
+        path = path.slice(0, path.length - 1)
+      }
+      return path
+    }).join('/')
   }
-  return linkUrl
+  return pathUrl
 }
 
 /**
  * Composes and returns a PATCH SPARQL query (for use with `web.patch()`)
  * @method composePatchQuery
- * @param toDel {Array<String>} List of triples to delete
- * @param toIns {Array<String>} List of triples to insert
+ * @param toDel {Array<String|Statement>} List of triples to delete
+ * @param toIns {Array<String|Statement>} List of triples to insert
  * @return {String} SPARQL query for use with PATCH
  */
 function composePatchQuery (toDel, toIns) {
   var query = ''
-
+  var excludeDot = true
   if (toDel && toDel.length > 0) {
-    toDel = toDel.map(function (each) {
-      if (each.endsWith('.')) {
-        each = each.slice(0, -1)
-      }
-      return each
+    toDel = toDel.map(function (st) {
+      return graphUtil.statementToNT(st, excludeDot)
     })
     query += 'DELETE DATA { ' + toDel.join(' . ') + ' };\n'
   }
   if (toIns && toIns.length > 0) {
-    toIns = toIns.map(function (each) {
-      if (each.endsWith('.')) {
-        each = each.slice(0, -1)
-      }
-      return each
+    toIns = toIns.map(function (st) {
+      return graphUtil.statementToNT(st, excludeDot)
     })
     query += 'INSERT DATA { ' + toIns.join(' . ') + ' };\n'
   }

--- a/package.json
+++ b/package.json
@@ -10,9 +10,9 @@
     "dist"
   ],
   "scripts": {
-    "build-with-rdflib": "browserify -r ./index.js:solid --exclude 'xhr2' -d -p [minifyify --no-map] --standalone 'SolidClient' -o dist/solid-client.min.js",
-    "build-without-rdflib": "browserify -r ./index.js:solid --exclude 'xhr2' --exclude 'rdflib' -d -p [minifyify] --standalone 'SolidClient' -o dist/solid-client-no-rdflib.min.js",
-    "build-qunit-resources": "npm run clean && mkdir -p dist/resources && npm run build-without-rdflib && browserify -r ./test/resources/profile-minimal.js:test-minimal-profile -o dist/resources/test-minimal-profile.js && browserify -r ./test/resources/profile-private.js:test-minimal-prefs -o dist/resources/test-minimal-prefs.js",
+    "build-with-rdflib": "browserify -r ./index.js:solid --exclude 'xhr2' -d -p [minifyify --map dist/solid-client.js.map --output dist/solid-client.js.map] --standalone 'SolidClient' -o dist/solid-client.min.js",
+    "build-without-rdflib": "browserify -r ./index.js:solid --exclude 'xhr2' --exclude 'rdflib' -d -p [minifyify --map dist/solid-client-no-rdflib.js.map --output dist/solid-client-no-rdflib.js.map] --standalone 'SolidClient' -o dist/solid-client-no-rdflib.min.js",
+    "build-qunit-resources": "npm run clean && mkdir -p dist/resources && npm run build-with-rdflib && browserify -r ./test/resources/profile-minimal.js:test-minimal-profile -o dist/resources/test-minimal-profile.js && browserify -r ./test/resources/profile-private.js:test-minimal-prefs -o dist/resources/test-minimal-prefs.js",
     "build": "npm run test && npm run clean && mkdir dist && npm run build-with-rdflib && npm run build-without-rdflib",
     "prepublish": "npm run build",
     "clean": "rm -rf dist/",
@@ -58,6 +58,7 @@
   "standard": {
     "globals": [
       "$rdf",
+      "SolidClient",
       "tabulator",
       "QUnit"
     ]

--- a/package.json
+++ b/package.json
@@ -11,15 +11,15 @@
   ],
   "scripts": {
     "build-with-rdflib": "browserify -r ./index.js:solid --exclude 'xhr2' -d -p [minifyify --no-map] --standalone 'SolidClient' -o dist/solid-client.min.js",
-    "build-without-rdflib": "browserify -r ./index.js:solid --exclude 'xhr2' --exclude 'rdflib' -d -p [minifyify --no-map] --standalone 'SolidClient' -o dist/solid-client-no-rdflib.min.js",
-    "build-qunit-resources": "browserify -r ./test/resources/profile-ldnode.js:test-ldnode-profile --exclude 'xhr2' --exclude 'rdflib' -o dist/resources/test-ldnode-profile.js",
+    "build-without-rdflib": "browserify -r ./index.js:solid --exclude 'xhr2' --exclude 'rdflib' -d -p [minifyify] --standalone 'SolidClient' -o dist/solid-client-no-rdflib.min.js",
+    "build-qunit-resources": "npm run clean && mkdir -p dist/resources && npm run build-without-rdflib && browserify -r ./test/resources/profile-minimal.js:test-minimal-profile -o dist/resources/test-minimal-profile.js && browserify -r ./test/resources/profile-private.js:test-minimal-prefs -o dist/resources/test-minimal-prefs.js",
     "build": "npm run test && npm run clean && mkdir dist && npm run build-with-rdflib && npm run build-without-rdflib",
     "prepublish": "npm run build",
     "clean": "rm -rf dist/",
     "standard": "standard lib/*",
     "tape": "tape test/unit/*.js",
     "test": "npm run standard && npm run tape",
-    "qunit": "npm run standard && npm run build-browserified && open test/integration/index.html"
+    "qunit": "npm run build-qunit-resources && open test/integration/index.html"
   },
   "repository": {
     "type": "git",

--- a/test/integration/index.html
+++ b/test/integration/index.html
@@ -10,9 +10,10 @@
   <div id="qunit"></div>
   <div id="qunit-fixture"></div>
   <script src="../../vendor/qunit-1.21.0.js"></script>
-  <script src="https://linkeddata.github.io/rdflib.js/archive/rdflib-0.5.0.min.js"></script>
+  <script src="https://solid.github.io/releases/rdflib.js/rdflib-0.7.0.min.js"></script>
   <script src="../../dist/solid.js"></script>
-  <script src="../../dist/resources/test-ldnode-profile.js"></script>
+  <script src="../../dist/resources/test-minimal-profile.js"></script>
+  <script src="../../dist/resources/test-minimal-prefs.js"></script>
   <script src="./web-client-test.js"></script>
   <script src="./solid-profile-test.js"></script>
 </body>

--- a/test/integration/index.html
+++ b/test/integration/index.html
@@ -10,8 +10,7 @@
   <div id="qunit"></div>
   <div id="qunit-fixture"></div>
   <script src="../../vendor/qunit-1.21.0.js"></script>
-  <script src="https://solid.github.io/releases/rdflib.js/rdflib-0.7.0.min.js"></script>
-  <script src="../../dist/solid.js"></script>
+  <script src="../../dist/solid-client.min.js"></script>
   <script src="../../dist/resources/test-minimal-profile.js"></script>
   <script src="../../dist/resources/test-minimal-prefs.js"></script>
   <script src="./web-client-test.js"></script>

--- a/test/integration/solid-profile-test.js
+++ b/test/integration/solid-profile-test.js
@@ -1,6 +1,6 @@
 'use strict'
 
-var solid = require('solid')
+var solid = SolidClient
 var vocab = solid.vocab
 
 var serverUrl = 'https://localhost:8443/'

--- a/test/integration/solid-profile-test.js
+++ b/test/integration/solid-profile-test.js
@@ -1,27 +1,246 @@
 'use strict'
 
 var solid = require('solid')
+var vocab = solid.vocab
 
 var serverUrl = 'https://localhost:8443/'
-var profileUrl = serverUrl + 'profile/card'
-// var sampleProfileUrl = 'https://localhost:8443/profile/card'
+var profileUrl = serverUrl + 'profile/test-profile-card'
+var rawProfileSource = require('test-minimal-profile')
+var prefsUrl = serverUrl + 'settings/test-test.ttl'
+var rawPrefsSource = require('test-minimal-prefs')
+var defaultPrivateTypeRegistryUrl = serverUrl + 'profile/privateTypeIndex.ttl'
+var defaultPublicTypeRegistryUrl = serverUrl + 'profile/publicTypeIndex.ttl'
 
-QUnit.module('SolidProfile tests')
+function clearRegistries () {
+  return clearResource(defaultPublicTypeRegistryUrl)
+    .then(function () {
+      return clearResource(defaultPrivateTypeRegistryUrl)
+    })
+}
 
-/**
- * Runs before the test suite, creates a `profile/test-profile-card` resource
- * (see `test/resources/profile-ldnode.js` for the Turtle source code).
- */
-QUnit.begin(function (details) {
-  // solid.web.put(profileUrl, rawProfileSource, 'text/turtle')
+function clearResource (url) {
+  return solid.web.del(url)
+    .catch(function () {
+      // do nothing (likely tried to delete a non-existent resource)
+    })
+}
+
+function ensureProfile (profileUrl) {
+  var createProfile = false
+  return solid.web.head(profileUrl)
+    .catch(function (error) {
+      if (error.code === 404) {
+        console.log('Profile not found.')
+        createProfile = true
+      } else {
+        console.log('Error on HEAD profile url:', error)
+      }
+      return createProfile
+    })
+    .then(function () {
+      if (createProfile) {
+        console.log('Creating test profile...')
+        return solid.web.put(profileUrl, rawProfileSource, 'text/turtle')
+      } else {
+        console.log('Profile detected, no problem.')
+      }
+    })
+    .catch(function (error) {
+      console.log('Error creating test profile:', error)
+    })
+    .then(function () {
+      if (createProfile) {
+        console.log('Profile created.')
+      }
+    })
+}
+
+function resetProfile (url) {
+  console.log('Resetting profile...')
+  // First, delete the current profile
+  return clearResource(url)
+    .then(function () {
+      // Re-add the profile from template
+      return ensureProfile(url)
+    })
+    .then(function () {
+      // Delete the private profile (prefs.ttl)
+      return clearResource(prefsUrl)
+    })
+    .then(function () {
+      // Re-add the private profile
+      return solid.web.put(prefsUrl, rawPrefsSource, 'text/turtle')
+    })
+    .then(function () {
+      return solid.getProfile(profileUrl)
+    })
+}
+
+QUnit.module('SolidProfile tests', {
+  /**
+   * Runs after the last test in this module
+   */
+  after: function (details) {
+    return resetProfile(profileUrl)
+      .then(function () {
+        console.log('Profile reset.')
+        return clearRegistries()
+      })
+  }
 })
 
 QUnit.test('getProfile() test', function (assert) {
   assert.expect(3)
-  return solid.getProfile(profileUrl)
+  return ensureProfile(profileUrl)
+    .then(function () {
+      return solid.getProfile(profileUrl)
+    })
     .then(function (profile) {
       assert.ok(profile.isLoaded)
-      assert.equal(profile.response.type, 'http://www.w3.org/ns/ldp#Resource')
+      assert.deepEqual(profile.response.types,
+        ['http://www.w3.org/ns/ldp#Resource'])
       assert.deepEqual(profile.storage, [serverUrl])
+    })
+})
+
+QUnit.test('initTypeRegistryPublic() test', function (assert) {
+  assert.expect(6)
+  var profile
+  return clearResource(defaultPublicTypeRegistryUrl)
+    .then(function () {
+      // Make sure registry does not exist
+      // return resetProfile(profileUrl)
+      return solid.getProfile(profileUrl)
+    })
+    .then(function (profileResult) {
+      profile = profileResult
+      return solid.typeRegistry.initTypeRegistryPublic(profile)
+    })
+    .then(function () {
+      // Check to make sure the type index is loaded after init
+      assert.ok(profile.hasTypeRegistryPublic())
+      assert.equal(profile.typeIndexListed.uri, defaultPublicTypeRegistryUrl,
+        'public type index uri should be loaded after registry init')
+      assert.ok(profile.typeIndexListed.graph,
+        'public type index graph should be loaded after init')
+      // reload the profile
+      return solid.getProfile(profileUrl)
+    })
+    .then(function (profileResult) {
+      profile = profileResult
+      assert.ok(profile.hasTypeRegistryPublic(),
+        'hasTypeRegistryPublic() should be true after initTypeRegistryPublic() + profile reload')
+      assert.equal(profile.typeIndexListed.uri, defaultPublicTypeRegistryUrl,
+        'public type index uri should be loaded after registry init + profile reload')
+      // The profile has been reloaded, but the type registry wasn't loaded.
+      // Load it now.
+      return profile.loadTypeRegistry()
+    })
+    .then(function (profileResult) {
+      profile = profileResult
+      assert.ok(profile.typeIndexListed.graph,
+        'public type index graph should be loaded after profile reload + loadTypeRegistry()')
+      // Test to make sure that the freshly initialized registry is empty
+    })
+    .then(function () {
+      return clearResource(defaultPublicTypeRegistryUrl)
+    })
+})
+
+QUnit.test('initTypeRegistryPrivate() test', function (assert) {
+  assert.expect(6)
+  var profile
+  return clearResource(defaultPrivateTypeRegistryUrl)
+    .then(function () {
+      // Make sure registry does not exist
+      // return resetProfile(profileUrl)
+      return solid.getProfile(profileUrl)
+    })
+    .then(function (profileResult) {
+      profile = profileResult
+      return solid.typeRegistry.initTypeRegistryPrivate(profile)
+    })
+    .then(function () {
+      // Check to make sure the type index is loaded after init
+      assert.ok(profile.hasTypeRegistryPrivate())
+      assert.equal(profile.typeIndexUnlisted.uri, defaultPrivateTypeRegistryUrl,
+        'private type index uri should be loaded after registry init')
+      assert.ok(profile.typeIndexUnlisted.graph,
+        'private type index graph should be loaded after init')
+      // reload the profile
+      return solid.getProfile(profileUrl)
+    })
+    .then(function (profileResult) {
+      profile = profileResult
+      assert.ok(profile.hasTypeRegistryPrivate(),
+        'hasTypeRegistryPrivate() should be true after initTypeRegistryPrivate() + profile reload')
+      assert.equal(profile.typeIndexUnlisted.uri, defaultPrivateTypeRegistryUrl,
+        'private type index uri should be loaded after registry init + profile reload')
+      // The profile has been reloaded, but the type registry wasn't loaded.
+      // Load it now.
+      return profile.loadTypeRegistry()
+    })
+    .then(function (profileResult) {
+      profile = profileResult
+      assert.ok(profile.typeIndexUnlisted.graph,
+        'private type index graph should be loaded after profile reload + loadTypeRegistry()')
+      // Test to make sure that the freshly initialized registry is empty
+    })
+    .then(function () {
+      return clearResource(defaultPrivateTypeRegistryUrl)
+    })
+})
+
+QUnit.test('registerType() test', function (assert) {
+  assert.expect(4)
+  var classToRegister = vocab.sioc('Post')
+  var locationToRegister = 'https://localhost:8443/posts-container/'
+  var isListed = true
+  var profile
+  return clearRegistries()
+    .then(function () {
+      return resetProfile(profileUrl)
+    })
+    .then(function (profileResult) {
+      profile = profileResult
+      return profile.registerType(classToRegister, locationToRegister,
+        'container', isListed)
+    })
+    .then(function (profileResult) {
+      profile = profileResult
+      // Now the type is registered, and the profile's type registry is refreshed
+      // querying the registry now will include the new container
+      var registrations = profile.typeRegistryForClass(vocab.sioc('Post'))
+      assert.equal(registrations.length, 1)
+      var newRegistration = registrations[0]
+      assert.equal(newRegistration.locationType, 'container')
+      assert.equal(newRegistration.locationUri, locationToRegister)
+      assert.equal(newRegistration.rdfClass.uri, vocab.sioc('Post').uri)
+    })
+})
+
+/**
+ * Note: unregisterType() depends on registerType() having run first.
+ */
+QUnit.test('unregisterType() test', function (assert) {
+  assert.expect(1)
+  var classToRemove = vocab.sioc('Post')
+  var isListed = true
+  var profile
+  return solid.getProfile(profileUrl)
+    .then(function (profileResult) {
+      profile = profileResult
+      // At this point, the profile has been loaded, but the type registries
+      // have not been. They will be loaded during unregisterType()
+      return profile.unregisterType(classToRemove, isListed)
+    })
+    .then(function (profileResult) {
+      profile = profileResult
+      // Check to make sure the registration was removed
+      var registrations = profile.typeRegistryForClass(vocab.sioc('Post'))
+      assert.equal(registrations.length, 0)
+    })
+    .then(function () {
+      return clearRegistries()
     })
 })

--- a/test/integration/web-client-test.js
+++ b/test/integration/web-client-test.js
@@ -11,6 +11,8 @@ QUnit.test('web.head() test', function (assert) {
   return solid.web.head(serverUrl)
     .then(function (result) {
       assert.equal(result.xhr.status, 200)
-      assert.equal(result.type, 'http://www.w3.org/ns/ldp#BasicContainer')
+      assert.deepEqual(result.types,
+        ['http://www.w3.org/ns/ldp#BasicContainer',
+          'http://www.w3.org/ns/ldp#Container'])
     })
 })

--- a/test/integration/web-client-test.js
+++ b/test/integration/web-client-test.js
@@ -1,6 +1,6 @@
 'use strict'
 
-var solid = require('solid')
+var solid = SolidClient
 
 var serverUrl = 'https://localhost:8443/'
 

--- a/test/resources/profile-extended.js
+++ b/test/resources/profile-extended.js
@@ -15,7 +15,6 @@ module.exports = `@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
 
 <>
   a foaf:PersonalProfileDocument;
-  foaf:maker <#me>;
   foaf:primaryTopic <#me>;
   rdfs:seeAlso </settings/privateProfile1.ttl>.
 
@@ -23,20 +22,31 @@ module.exports = `@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
     a    foaf:Person;
     foaf:name "Alice";
     foaf:img </profile/img.png>;
+
+    # owl:sameAs, rdfs:seeAlso, and sp:preferencesFile link
+    #   to the Extended Profile
     owl:sameAs </settings/privateProfile2.ttl>;
     cert:key
        <#key-1455289666916>;
+    # This preferencesFile can be thought of as a private profile
     sp:preferencesFile
        </settings/prefs.ttl>;
     # Add a duplicate Preferences link, to test client side de-duplication
     sp:preferencesFile
        </settings/prefs.ttl>;
+
+    # Link to root storage container
     sp:storage
        loc:;
+    # Link to the public (listed) Type Registry index.
+    # The link to the private (unlisted) index is in the private profile
     terms:publicTypeIndex
        </settings/publicTypeIndex.ttl>;
+    # Link to the Solid messaging inbox
     terms:inbox
        inbox:.
+
+# Public key certificate section
 <#key-1455289666916>
     ter:created
        "2016-02-12T15:07:46.916Z"^^XML:dateTime;

--- a/test/resources/profile-minimal.js
+++ b/test/resources/profile-minimal.js
@@ -1,0 +1,24 @@
+/**
+ * Sample LDNode user profile, for use with `solid-profile-test.js`
+ */
+module.exports = `@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
+@prefix foaf: <http://xmlns.com/foaf/0.1/>.
+@prefix sp: <http://www.w3.org/ns/pim/space#>.
+@prefix loc: </>.
+@prefix terms: <http://www.w3.org/ns/solid/terms#>.
+@prefix inbox: </inbox/>.
+
+<>
+  a foaf:PersonalProfileDocument;
+  foaf:primaryTopic <#me>.
+
+<#me>
+    a    foaf:Person;
+    sp:preferencesFile
+       </settings/test-prefs.ttl>;
+
+    sp:storage
+       loc:;
+    terms:inbox
+       inbox:.
+`

--- a/test/resources/profile-private.js
+++ b/test/resources/profile-private.js
@@ -1,8 +1,9 @@
 /**
- * Sample LDNode preferences file, for use with `solid-profile-test.js`
+ * Sample "private profile"/preferences file, for use with
+ * `solid-profile-test.js`
  */
 module.exports = `
-# Located in /settings/prefs.ttl
+# Located in /settings/test-prefs.ttl
 
 <https://localhost:8443/profile/card#me>
     <http://www.w3.org/ns/solid/terms#privateTypeIndex> <privateTypeIndex.ttl> .

--- a/test/unit/solid-profile-test.js
+++ b/test/unit/solid-profile-test.js
@@ -75,8 +75,9 @@ test('SolidProfile .find() test', function (t) {
   expectedAnswer = 'https://localhost:8443/settings/privateProfile2.ttl'
   t.equal(profile.find(vocab.owl('sameAs')), expectedAnswer,
     '.find() should fetch owl:sameAs')
-  t.equal(profile.find(vocab.foaf('undefined-predicate')), undefined,
-    '.find() should return `undefined` for unspecified predicates')
+
+  t.notOk(profile.find(vocab.solid('invalidPredicate')),
+    'Trying to find() non-existent resources should return null')
   t.end()
 })
 
@@ -89,6 +90,9 @@ test('SolidProfile .findAll() test', function (t) {
   expectedAnswer = ['https://localhost:8443/settings/privateProfile2.ttl']
   t.deepEqual(profile.findAll(vocab.owl('sameAs')), expectedAnswer,
     '.findAll() should fetch all owl:sameAs values')
+
+  t.deepEqual(profile.findAll(vocab.solid('invalidPredicate')), [],
+    'findAll() on non-existent resources should return []')
   t.end()
 })
 

--- a/test/unit/type-registry-test.js
+++ b/test/unit/type-registry-test.js
@@ -7,10 +7,28 @@ var SolidProfile = require('../../lib/solid/profile')
 var vocab = require('../../lib/vocab')
 // var rdf = require('../../lib/util/rdf-parser').rdflib
 
-var rawProfileSource = require('../resources/profile-ldnode')
+var rawProfileSource = require('../resources/profile-extended')
 var sampleProfileUrl = 'https://localhost:8443/profile/card'
 var parsedProfileGraph = parseGraph(sampleProfileUrl,
   rawProfileSource, 'text/turtle')
+
+test('blankPrivateTypeIndex() test', function (t) {
+  let blankIndex = typeRegistry.blankPrivateTypeIndex()
+  t.equal(blankIndex.slug, 'privateTypeIndex.ttl')
+  t.notOk(blankIndex.uri)
+  t.equal(typeof blankIndex.data, 'string')
+  t.ok(blankIndex.graph)
+  t.end()
+})
+
+test('blankPublicTypeIndex() test', function (t) {
+  let blankIndex = typeRegistry.blankPublicTypeIndex()
+  t.equal(blankIndex.slug, 'publicTypeIndex.ttl')
+  t.notOk(blankIndex.uri)
+  t.equal(typeof blankIndex.data, 'string')
+  t.ok(blankIndex.graph)
+  t.end()
+})
 
 test('Solid.typeRegistry isListedTypeIndex test', function (t) {
   var url = 'https://localhost:8443/settings/publicTypeIndex.ttl'

--- a/test/unit/web-util-test.js
+++ b/test/unit/web-util-test.js
@@ -64,3 +64,17 @@ test('parseAllowedMethods() does not support json-patch', function (t) {
     acceptPatchHeader)
   t.deepEqual(allowedMethods, expectedAllowedMethods, 'JSON-Patch method is not supported')
 })
+
+test('hostname() test', function (t) {
+  var hostname = webUtil.hostname
+  t.equal(hostname('https://example.com'), 'https://example.com')
+  t.equal(hostname('https://example.com/'), 'https://example.com')
+  t.equal(hostname('//example.com/'), '//example.com')
+  t.equal(hostname('//example.com'), '//example.com')
+  t.equal(hostname('example.com'), 'example.com')
+  t.equal(hostname('https://username:password@www.example.com/'),
+    'https://username:password@www.example.com')
+  t.equal(hostname('https://example.com/dir1/'), 'https://example.com')
+  t.equal(hostname('https://example.com/dir1/dir2/#me?k=v'), 'https://example.com')
+  t.end()
+})


### PR DESCRIPTION
Closes issue #100.

- Improved the `absoluteUrl()` function
- Do not reload type indexes after patching
- Refactor existing type registry code
- Implement `initTypeRegistry*()` methods
- When registering types, if registry resources don't exist, they're created.