### PR TITLE
Make `.find()` handle unspecified predicates.

### DIFF
--- a/lib/solid/profile.js
+++ b/lib/solid/profile.js
@@ -212,7 +212,7 @@ SolidProfile.prototype.find = function find (predicate) {
   }
   var subject = rdf.sym(this.webId)
   var result = this.parsedGraph.any(subject, predicate)
-  return result.value || result.uri
+  return result ? (result.value || result.uri) : undefined
 }
 
 /**

--- a/test/unit/solid-profile-test.js
+++ b/test/unit/solid-profile-test.js
@@ -75,6 +75,8 @@ test('SolidProfile .find() test', function (t) {
   expectedAnswer = 'https://localhost:8443/settings/privateProfile2.ttl'
   t.equal(profile.find(vocab.owl('sameAs')), expectedAnswer,
     '.find() should fetch owl:sameAs')
+  t.equal(profile.find(vocab.foaf('undefined-predicate')), undefined,
+    '.find() should return `undefined` for unspecified predicates')
   t.end()
 })
 


### PR DESCRIPTION
@dmitrizagidulin - I ran into an issue using `.find()` to query the graph for predicates which haven't been defined.