### PR TITLE
Pass options param to HEAD requests

### DIFF
--- a/lib/web.js
+++ b/lib/web.js
@@ -175,10 +175,16 @@ var SolidWebClient = {
    *   metadata info.
    * @method head
    * @param url {String} URL of a resource or container
+   * @param [options] Options hashmap
+   * @param [options.headers] {Object} HTTP headers to send along with request
+   * @param [options.proxyUrl=config.proxyUrl] {String} Proxy URL to use for
+   *          CORS Requests.
+   * @param [options.timeout=config.timeout] {Number} Request timeout in
+   *          milliseconds.
    * @return {Promise} Result of an HTTP HEAD operation (returns a meta object)
    */
-  head: function head (url) {
-    return this.solidRequest(url, 'HEAD')
+  head: function head (url, options) {
+    return this.solidRequest(url, 'HEAD', options)
   },
 
   /**


### PR DESCRIPTION
Add the `options` object param to the `Solid.web.head()` method.