### PR TITLE
Bundle (or don't) rdflib, document installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,29 +8,37 @@ applications. (See **[Changelog](CHANGELOG.md)** for version history.)
 
 ## Usage
 
-Solid.js is currently intended for client-side use only (inside a web browser):
+The solid client can be used by solid applications that run in the browser or on
+Node.js. A minified UMD bundle is provided along with the regular set of
+CommonJS modules.
 
-1. Load dependencies (currently,
-  [rdflib.js](https://github.com/linkeddata/rdflib.js/)).
-2. Load `solid.js` from a local copy (or directly from Github Pages).
-3. Use the `require('solid')` function provided by Browserify to import.
-
-Example `index.html`:
+For example:
 
 ```html
-<script src="https://solid.github.io/releases/rdflib.js/rdflib-0.7.0.min.js"></script>
-<script src="https://solid.github.io/releases/solid.js/solid-0.18.0.min.js"></script>
-<script>
-  // $rdf is exported as a global when you load RDFLib, above
-  var solid = require('solid')
-  // Use Solid client here ...
-  console.log('solid.js version: ' + solid.meta.version())
-</script>
+<!DOCTYPE HTML>
+<html>
+  <head>
+    <script src="dist/solid-client.min.js"></script>
+  </head>
+  <body>
+    <script>
+      var solid = SolidClient
+    </script>
+  </body>
+</html>
 ```
+
+Or, using a module loader:
+
+```js
+var solid = require('solid-client')
+```
+
+See the [installation docs](docs/installing.md) for more installation examples.
 
 Take a look at the **[Solid.js Demo
 Page](https://solid.github.io/solid.js/demo/)** (source located in
-`demo/index.html`) for more usage examples.
+`demo/index.html`) for usage examples.
 
 ## Tutorials
 
@@ -227,7 +235,7 @@ the profile document itself, any `sameAs` and `seeAlso` links it finds there,
 as well as the Preferences file.
 
 Once a profile is loaded, you can access the values of the profile's pre-defined
-fields, or look for predicates in the profile's parsed graph using 
+fields, or look for predicates in the profile's parsed graph using
 `profile.find()` and `profile.findAll()`:
 
 ```js
@@ -288,7 +296,7 @@ var addressBookRegistrations = solid.getProfile(webId)
     locationUri: 'https://localhost:8443/personal-address-books/',
     locationType: 'container',
     isListed: false
-  )  
+  )
 ]
 */
 ```

--- a/docs/installing.md
+++ b/docs/installing.md
@@ -1,0 +1,87 @@
+# Installing
+
+The solid client library can be installed in several ways. It's designed to be
+run in Node.js and the browser. There are three primary distributions:
+
+1. The CommonJS module named `'solid-client'`
+2. The bundled and minified `solid-client.min.js`
+3. The bundled and minified `solid-client-no-rdflib.min.js` which does not
+   include the (current) hard dependency on
+   [`rdflib.js`](https://github.com/linkeddata/rdflib.js). This bundle is for
+   developers that want to include `rdflib.js` themselves.
+
+## Node.js
+
+Simply install solid-client through node and then `require('solid-client')`
+within your code!
+
+```sh
+$ npm install solid-client --save
+```
+
+```js
+var solid = require('solid-client')
+```
+
+## Browser
+
+We offer a few ways to install the solid client.
+
+### CDN
+
+If you don't need a module system, the simplest way to use the solid client in
+an app is to add the `solid-client.min.js` bundle to your page.
+
+```html
+<script src="dist/solid-client.min.js"></script>
+```
+
+If you're using the `solid-client-no-rdflib.min.js` bundle, you'll need to
+manually include its dependency on `rdflib.js`.
+
+```html
+<script src="https://solid.github.io/releases/rdflib.js/rdflib-0.7.0.min.js"></script>
+<script src="dist/solid-client.min.js"></script>
+```
+
+### browserify
+
+```sh
+$ npm install solid-client --save
+```
+
+```js
+var solid = require('solid-client')
+```
+
+### webpack
+
+Using solid-client with webpack requires some configuration. You'll need the
+json-loader for webpack and will need to exclude the xhr2 module from the build.
+
+First install solid-client and json-loader:
+
+```sh
+$ npm install solid-client --save
+$ npm install json-loader --save-dev
+```
+
+Then add the JSON loader and declare the xhr2 external in `webpack.config.js`:
+
+```js
+module.exports = {
+  // ...
+  module: {
+    loaders: [
+      {
+        test: /\.json$/,
+        loader: 'json'
+      }
+    ]
+  },
+  externals: {
+    'xhr2': 'XMLHttpRequest'
+  },
+  // ...
+}
+```

--- a/index.js
+++ b/index.js
@@ -21,9 +21,7 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
-Solid.js is a Javascript library for Solid applications. This library currently
-depends on rdflib.js. Please make sure to load the rdflib.js script before
-loading solid.js.
+Solid.js is a Javascript library for Solid applications.
 
 If you would like to know more about the solid Solid project, please see
 https://github.com/solid/solid
@@ -50,6 +48,7 @@ var Solid = {
   identity: require('./lib/identity'),
   login: require('./lib/auth').login,
   meta: require('./lib/meta'),
+  rdflib: (typeof $rdf !== 'undefined') ? $rdf : require('rdflib'),
   signup: require('./lib/auth').signup,
   status: require('./lib/status'),
   vocab: require('./lib/vocab'),

--- a/lib/util/rdf-parser.js
+++ b/lib/util/rdf-parser.js
@@ -10,11 +10,8 @@ if (typeof $rdf !== 'undefined') {
   RDFParser.rdflib = $rdf // FF extension
 } else if (typeof tabulator !== 'undefined') {
   RDFParser.rdflib = tabulator.rdf
-} else if (typeof window !== 'undefined') {
-  // Running inside the browser but NOT FF extension
-  RDFParser.rdflib = window.$rdf
-} else {
-  // in Node.js
+} else if (typeof require === 'function') {
+  // Running with a CommonJS module system
   RDFParser.rdflib = require('rdflib')
 }
 module.exports = RDFParser

--- a/package.json
+++ b/package.json
@@ -10,10 +10,10 @@
     "dist"
   ],
   "scripts": {
-    "build-browserified": "browserify -r ./index.js:solid --exclude 'xhr2' --exclude 'rdflib' --standalone 'SolidClient' > dist/solid.js",
-    "build-minified": "browserify -r ./index.js:solid --exclude 'xhr2' --exclude 'rdflib' -d -p [minifyify --no-map] --standalone 'SolidClient' > dist/solid.min.js",
-    "build": "npm run clean && mkdir -p dist/resources && npm run standard && npm run build-browserified && npm run build-minified",
-    "build-qunit-resources": "browserify -r ./test/resources/profile-ldnode.js:test-ldnode-profile --exclude 'xhr2' --exclude 'rdflib' > dist/resources/test-ldnode-profile.js",
+    "build-with-rdflib": "browserify -r ./index.js:solid --exclude 'xhr2' -d -p [minifyify --no-map] --standalone 'SolidClient' -o dist/solid-client.min.js",
+    "build-without-rdflib": "browserify -r ./index.js:solid --exclude 'xhr2' --exclude 'rdflib' -d -p [minifyify --no-map] --standalone 'SolidClient' -o dist/solid-client-no-rdflib.min.js",
+    "build-qunit-resources": "browserify -r ./test/resources/profile-ldnode.js:test-ldnode-profile --exclude 'xhr2' --exclude 'rdflib' -o dist/resources/test-ldnode-profile.js",
+    "build": "npm run test && npm run clean && mkdir dist && npm run build-with-rdflib && npm run build-without-rdflib",
     "prepublish": "npm run build",
     "clean": "rm -rf dist/",
     "standard": "standard lib/*",


### PR DESCRIPTION
This PR should resolve some confusion around how a client application should include the solid.js client.

There are two basic options:

1. Include the minified bundle inside `<script>` tags.
  - Bundles with and without `rdflib` are provided. Note that the bundles will have new names - `solid-client.min.js` and `solid-client-no-rdflib.min.js` (let me know if you have any less verbose suggestions)

2. Use the CommonJS modules

Both examples are now documented in `docs/installing.md`

@dmitrizagidulin please review?

FYI @deiu 